### PR TITLE
added support for code-blocks

### DIFF
--- a/tasks/wp_readme_to_markdown.js
+++ b/tasks/wp_readme_to_markdown.js
@@ -45,7 +45,7 @@ module.exports = function(grunt) {
 
 		//convert code blocks
 		grunt.log.debug("Convert code blocks");
-    readme = readme.replace( new RegExp("`([^`]*[\n.]*)`", "i"), "```$1```");
+    readme = readme.replace( new RegExp("`([^`]*[\n.]*)`", "i"), "```\n$1\n```");
 
 		//guess plugin slug from plugin name
 		//@todo Get this from config instead?


### PR DESCRIPTION
converts

`function oexchange_target_link($array) {
  $array["links"][] = array("rel" => "http://oexchange.org/spec/0.8/rel/resident-target",
    "href" => "http://example.com",
    "type" => "application/xrd+xml");
  return $array;
}
add_filter('webfinger', 'oexchange_target_link');`

into

```
function oexchange_target_link($array) {
  $array["links"][] = array("rel" => "http://oexchange.org/spec/0.8/rel/resident-target",
    "href" => "http://example.com",
    "type" => "application/xrd+xml");
  return $array;
}
add_filter('webfinger', 'oexchange_target_link');
```
