### PR TITLE
Update screenshots url to new domain

### DIFF
--- a/tasks/wp_readme_to_markdown.js
+++ b/tasks/wp_readme_to_markdown.js
@@ -16,7 +16,7 @@ module.exports = function(grunt) {
  grunt.registerMultiTask('wp_readme_to_markdown', 'Converts WP readme.txt file to markdown (readme.md)', function() {
 
 	var options = this.options({
-		screenshot_url: 'http://s.wordpress.org/extend/plugins/{plugin}/{screenshot}.png',
+		screenshot_url: 'http://ps.w.org/{plugin}/assets/{screenshot}.png',
 	});
 	
 	grunt.verbose.writeflags( options );

--- a/test/expected/readme.md
+++ b/test/expected/readme.md
@@ -60,13 +60,13 @@ Answer to foo bar dilemma.
 ## Screenshots ##
 
 ### 1. This screen shot description corresponds to screenshot-1.(png|jpg|jpeg|gif). Note that the screenshot is taken from ###
-![This screen shot description corresponds to screenshot-1.(png|jpg|jpeg|gif). Note that the screenshot is taken from](http://s.wordpress.org/extend/plugins/plugin-name/screenshot-1.png)
+![This screen shot description corresponds to screenshot-1.(png|jpg|jpeg|gif). Note that the screenshot is taken from](http://ps.w.org/plugin-name/assets/screenshot-1.png)
 
 the /assets directory or the directory that contains the stable readme.txt (tags or trunk). Screenshots in the /assets 
 directory take precedence. For example, `/assets/screenshot-1.png` would win over `/tags/4.3/screenshot-1.png` 
 (or jpg, jpeg, gif).
 ### 2. This is the second screen shot ###
-![This is the second screen shot](http://s.wordpress.org/extend/plugins/plugin-name/screenshot-2.png)
+![This is the second screen shot](http://ps.w.org/plugin-name/assets/screenshot-2.png)
 
 
 ## Changelog ##


### PR DESCRIPTION
New domain for plugin assets data is ps.w.org, so now plugin screenshots available by ps.w.org/plugin-name/assets/screenshot-1.png