### PR TITLE
Release/2.0.0

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -40,7 +40,7 @@ module.exports = function(grunt) {
       },
       without_screenshot_section: {
 		files: {
-			'tmp/readme-without-screenshots.md': 'test/fixtures/readme-without-screenshots.txt',
+          'tmp/readme-without-screenshots.md': 'test/fixtures/readme-without-screenshots.txt',
 		},
         options: {
           screenshot_url: 'http://ps.w.org/{plugin}/assets/{screenshot}.png'
@@ -48,7 +48,7 @@ module.exports = function(grunt) {
       },
       with_spaces_after_headers: {
 		files: {
-			'tmp/readme-with-spaces-after-headers.md': 'test/fixtures/readme-with-spaces-after-headers.txt',
+          'tmp/readme-with-spaces-after-headers.md': 'test/fixtures/readme-with-spaces-after-headers.txt',
 		},
         options: {
           screenshot_url: 'http://ps.w.org/{plugin}/assets/{screenshot}.png'
@@ -56,16 +56,15 @@ module.exports = function(grunt) {
       },
       with_spaces_between_plugin_details: {
 		files: {
-			'tmp/readme-with-spaces-between-plugin-details.md': 'test/fixtures/readme-with-spaces-between-plugin-details.txt',
+          'tmp/readme-with-spaces-between-plugin-details.md': 'test/fixtures/readme-with-spaces-between-plugin-details.txt',
 		},
         options: {
           screenshot_url: 'http://ps.w.org/{plugin}/assets/{screenshot}.png'
         }
       },
-	
       with_code_blocks: {
 		files: {
-			'tmp/readme-with-code-blocks.md': 'test/fixtures/readme-with-code-blocks.txt',
+          'tmp/readme-with-code-blocks.md': 'test/fixtures/readme-with-code-blocks.txt',
 		},
         options: {
           screenshot_url: 'http://ps.w.org/{plugin}/assets/{screenshot}.png'
@@ -73,7 +72,7 @@ module.exports = function(grunt) {
       },
       with_screenshots_disabled: {
 		files: {
-			'tmp/readme-screenshots-disabled.md': 'test/fixtures/readme.txt',
+          'tmp/readme-screenshots-disabled.md': 'test/fixtures/readme.txt',
 		},
       },
     },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,29 +34,48 @@ module.exports = function(grunt) {
         files: {
           'tmp/readme.md': 'test/fixtures/readme.txt',
         },
+        options: {
+          screenshot_url: 'http://ps.w.org/{plugin}/assets/{screenshot}.png'
+        }
       },
       without_screenshot_section: {
 		files: {
 			'tmp/readme-without-screenshots.md': 'test/fixtures/readme-without-screenshots.txt',
-		}
+		},
+        options: {
+          screenshot_url: 'http://ps.w.org/{plugin}/assets/{screenshot}.png'
+        }
       },
       with_spaces_after_headers: {
 		files: {
 			'tmp/readme-with-spaces-after-headers.md': 'test/fixtures/readme-with-spaces-after-headers.txt',
-		}
+		},
+        options: {
+          screenshot_url: 'http://ps.w.org/{plugin}/assets/{screenshot}.png'
+        }
       },
       with_spaces_between_plugin_details: {
 		files: {
 			'tmp/readme-with-spaces-between-plugin-details.md': 'test/fixtures/readme-with-spaces-between-plugin-details.txt',
-		}
+		},
+        options: {
+          screenshot_url: 'http://ps.w.org/{plugin}/assets/{screenshot}.png'
+        }
       },
 	
       with_code_blocks: {
 		files: {
 			'tmp/readme-with-code-blocks.md': 'test/fixtures/readme-with-code-blocks.txt',
-		}
+		},
+        options: {
+          screenshot_url: 'http://ps.w.org/{plugin}/assets/{screenshot}.png'
+        }
       },
-
+      with_screenshots_disabled: {
+		files: {
+			'tmp/readme-screenshots-disabled.md': 'test/fixtures/readme.txt',
+		},
+      },
     },
 
     // Unit tests.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -75,6 +75,30 @@ module.exports = function(grunt) {
           'tmp/readme-screenshots-disabled.md': 'test/fixtures/readme.txt',
 		},
       },
+      with_appended_header_pre_convert: {
+		files: {
+          'tmp/readme-pre-convert-filter.md': 'test/fixtures/readme.txt',
+		},
+		options: {
+          screenshot_url: 'http://ps.w.org/{plugin}/assets/{screenshot}.png',
+          pre_convert: function( readme ) {
+              readme += "\n== My Additional Header ==\n\n My additional text";
+              return readme;
+          }
+		}
+      },
+      with_appended_header_post_convert: {
+		files: {
+          'tmp/readme-post-convert-filter.md': 'test/fixtures/readme.txt',
+		},
+		options: {
+          screenshot_url: 'http://ps.w.org/{plugin}/assets/{screenshot}.png',
+          post_convert: function( readme ) {
+              readme += "\n== My Additional Header ==\n\nHeader is not converted as it is added after conversion.";
+              return readme;
+          }
+		}
+      },
     },
 
     // Unit tests.

--- a/README.md
+++ b/README.md
@@ -35,10 +35,20 @@ grunt.initConfig({
 ### Options
 
 #### screenshot_url
-Type: `String`
-Default value: `http://ps.w.org/{plugin}/assets/{screenshot}.png`
+Type: `String`/`Bool`    
+Default value: `false`
 
-The url used for the screenshot images. `{plugin}` is replaced by the plug-in name (as determined by the readme) and `{screenshot}` is replaced by `screenshot-X` where `X` is a number indexing the screenshots (starting from 1). 
+*Prior to 2.0.0 the default value had been `http://ps.w.org/{plugin}/assets/{screenshot}.png`. Please see [#14](https://github.com/stephenharris/wp-readme-to-markdown/issues/14) for the reasons for the change.* 
+
+The url/path used for the screenshot images. If left as `false`, no screenshots will be included. Alternatively you can provide a:
+
+ 1. A relative path to the images (commited to the repo) `assets/{screenshot}.png`
+ 2. A URL to a website hosting the images: `http://example.com/{screenshot}.png`
+ 3. The wordpress.org hosted screenshots**\***: `http://ps.w.org/{plugin}/assets/{screenshot}.png`
+
+There are placeholders to available for use in the URL structure. `{plugin}` is replaced by the plug-in name (as determined by the readme) and `{screenshot}` is replaced by `screenshot-X` where `X` is a number indexing the screenshots (starting from 1). 
+
+**\*** Actual URL of the wordpress.org hosted screenshots can vary. Please see [#14](https://github.com/stephenharris/wp-readme-to-markdown/issues/14) for details.
 
 ### Usage Examples
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 
 ## Release History
 
+### 2.0.0 - 31st May 2016
+- **Breaking change:** The default value of `screenshot_url` has been changed from `http://ps.w.org/{plugin}/assets/{screenshot}.png` to `false`. By default no screenshot images are included in the generated `readme.md`. Please see [#14](https://github.com/stephenharris/wp-readme-to-markdown/issues/14) for details.
+- Contributors have their links to their wordpress.org profile automatically inserted. [#12](https://github.com/stephenharris/wp-readme-to-markdown/issues/12)
+- Added `pre_convert` and `post_convert` options
+
 ### 1.0.0
 - Changed the default value of the screen short URL
 - Fix for the fact lines with colons are being parsed as if they were readme tags. Fixes [#3](https://github.com/stephenharris/wp-readme-to-markdown/issues/3). ). Thanks to @marcochiesi.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ There are placeholders to available for use in the URL structure. `{plugin}` is 
 
 **\*** Actual URL of the wordpress.org hosted screenshots can vary. Please see [#14](https://github.com/stephenharris/wp-readme-to-markdown/issues/14) for details.
 
+#### pre_convert
+Type: `function`    
+Default value: `noop`
+
+A function which filters the value of the original readme file before it is converted. You should return the (modified) content. Returning a `false` value has the same effect as not providing a callback at all: the original readme file content is used.
+
+#### pre_convert
+Type: `function`    
+Default value: `noop`
+
+A function which filters the value of the converted readme content immediately before it is written to file. You should return the (modified) content. Returning a `false` value has the same effect as not providing a callback at all: the converted readme content is written to file unchanged.
+
 ### Usage Examples
 
 #### Default Options

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Default value: `false`
 
 *Prior to 2.0.0 the default value had been `http://ps.w.org/{plugin}/assets/{screenshot}.png`. Please see [#14](https://github.com/stephenharris/wp-readme-to-markdown/issues/14) for the reasons for the change.* 
 
-The url/path used for the screenshot images. If left as `false`, no screenshots will be included. Alternatively you can provide a:
+The url/path used for the screenshot images. If left as `false`, no screenshot images will be included. Alternatively you can provide a:
 
  1. A relative path to the images (commited to the repo) `assets/{screenshot}.png`
  2. A URL to a website hosting the images: `http://example.com/{screenshot}.png`

--- a/tasks/wp_readme_to_markdown.js
+++ b/tasks/wp_readme_to_markdown.js
@@ -16,7 +16,9 @@ module.exports = function(grunt) {
  grunt.registerMultiTask('wp_readme_to_markdown', 'Converts WP readme.txt file to markdown (readme.md)', function() {
 
 	var options = this.options({
-		screenshot_url: false
+		screenshot_url: false,
+		pre_convert: function( readme ){},
+		post_convert: function( readme ){}
 	});
 
 	grunt.verbose.writeflags( options );
@@ -35,6 +37,8 @@ module.exports = function(grunt) {
 			// Read file source.
 			return grunt.file.read(filepath);
 		}).join(grunt.util.normalizelf(' '));
+
+		readme = options.pre_convert(readme) || readme;
 
 		/* The following is a ported version of {@see https://github.com/benbalter/WP-Readme-to-Github-Markdown}*/
 
@@ -115,6 +119,8 @@ module.exports = function(grunt) {
 			//Add newline and indent all lines in the codeblock by one tab.
 			return "\n\t" + lines.join("\n\t") + "\n"; //trailing newline is unnecessary but adds some symmetry.
 		});
+
+		readme = options.post_convert(readme) || readme;
 
 		// Write the destination file.
 		grunt.file.write( f.dest, readme );

--- a/tasks/wp_readme_to_markdown.js
+++ b/tasks/wp_readme_to_markdown.js
@@ -16,7 +16,7 @@ module.exports = function(grunt) {
  grunt.registerMultiTask('wp_readme_to_markdown', 'Converts WP readme.txt file to markdown (readme.md)', function() {
 
 	var options = this.options({
-		screenshot_url: 'http://ps.w.org/{plugin}/assets/{screenshot}.png',
+		screenshot_url: false
 	});
 
 	grunt.verbose.writeflags( options );
@@ -83,7 +83,7 @@ module.exports = function(grunt) {
 		//process screenshots, if any
 		grunt.log.debug("Get screenshots");
 		var screenshot_match = readme.match( new RegExp("## Screenshots ##([^#]*)","im") );
-		if ( _match && screenshot_match && screenshot_match.length > 1 ) {
+		if ( options.screenshot_url && _match && screenshot_match && screenshot_match.length > 1 ) {
 
 			var plugin = _match[1].trim().toLowerCase().replace(/ /g, '-');
 

--- a/tasks/wp_readme_to_markdown.js
+++ b/tasks/wp_readme_to_markdown.js
@@ -18,7 +18,7 @@ module.exports = function(grunt) {
 	var options = this.options({
 		screenshot_url: 'http://ps.w.org/{plugin}/assets/{screenshot}.png',
 	});
-	
+
 	grunt.verbose.writeflags( options );
 	this.files.forEach(function(f) {
 
@@ -29,7 +29,7 @@ module.exports = function(grunt) {
 				grunt.log.warn('Source file "' + filepath + '" not found.');
 				return false;
 			} else {
-				return true; 
+				return true;
 			}
 		}).map(function(filepath) {
 			// Read file source.
@@ -38,9 +38,9 @@ module.exports = function(grunt) {
 
 		/* The following is a ported version of {@see https://github.com/benbalter/WP-Readme-to-Github-Markdown}*/
 
-		//Convert Headings 
+		//Convert Headings
 		grunt.log.debug("Converting headings");
-		readme = readme.replace( new RegExp("^=([^=]+)=*?[\\s ]*?$","gim"),"###$1###");	
+		readme = readme.replace( new RegExp("^=([^=]+)=*?[\\s ]*?$","gim"),"###$1###");
 		readme = readme.replace( new RegExp("^==([^=]+)==*?[\\s ]*?$","mig"),"##$1##");
 		readme = readme.replace( new RegExp("^===([^=]+)===*?[\\s ]*?$","gim"),"#$1#");
 
@@ -53,19 +53,41 @@ module.exports = function(grunt) {
 			readme = readme.replace( header_search, header_replace );
 		}
 
+		// Include w.org profiles for contributors.
+		grunt.log.debug("Including contributors profiles");
+		var contributors_match = readme.match( new RegExp("(\\*\\*Contributors:\\*\\* )(.+)", "m") );
+		if ( header_match && header_match.length >= 1 ) {
+			var contributors_search = contributors_match[0];
+			var contributors_replace = contributors_match[1];
+			var profiles = [];
+
+			// Fill profiles.
+			contributors_match[2].split(",").forEach(function(value) {
+				value = value.trim();
+				profiles.push("[" + value + "](https://profiles.wordpress.org/" + value + ")");
+			});
+
+			contributors_replace += profiles.join(", ");
+
+			// Add line break.
+			contributors_replace += '  ';
+
+			readme = readme.replace( contributors_search, contributors_replace );
+		}
+
 		//guess plugin slug from plugin name
 		//@todo Get this from config instead?
 		grunt.log.debug("Get plugin name");
-		var _match =  readme.match( new RegExp("^#([^#]+)#[\\s ]*?$","im") );	
+		var _match =  readme.match( new RegExp("^#([^#]+)#[\\s ]*?$","im") );
 
 		//process screenshots, if any
 		grunt.log.debug("Get screenshots");
 		var screenshot_match = readme.match( new RegExp("## Screenshots ##([^#]*)","im") );
 		if ( _match && screenshot_match && screenshot_match.length > 1 ) {
-			
+
 			var plugin = _match[1].trim().toLowerCase().replace(/ /g, '-');
-	
-			//Collect screenshots content	
+
+			//Collect screenshots content
 			var screenshots = screenshot_match[1];
 
 			//parse screenshot list into array
@@ -76,7 +98,7 @@ module.exports = function(grunt) {
 				nonGlobalMatch = globalMatch[i].match(  new RegExp( "^[0-9]+\\. (.*)", 'im' ) );
 				matchArray.push( nonGlobalMatch[1] );
 			}
-		
+
 			//replace list item with markdown image syntax, hotlinking to plugin repo
 			//@todo assumes .png, perhaps should check that file exists first?
 			for( i=1; i <= matchArray.length; i++ ) {
@@ -86,7 +108,7 @@ module.exports = function(grunt) {
 				readme = readme.replace(  globalMatch[i-1], "### "+i+". "+ matchArray[i-1] +" ###\n!["+matchArray[i-1]+"](" + url + ")\n" );
 			}
 		}
-		
+
 		//Code blocks
 		readme = readme.replace( new RegExp("^`$[\n\r]+([^`]*)[\n\r]+^`$","gm"),function( codeblock, codeblockContents ){
 			var lines = codeblockContents.split("\n");
@@ -96,7 +118,7 @@ module.exports = function(grunt) {
 
 		// Write the destination file.
 		grunt.file.write( f.dest, readme );
-	
+
 		// Print a success message.
 		grunt.log.writeln('File "' + f.dest + '" created.');
 	});

--- a/test/expected/readme-post-convert-filter.md
+++ b/test/expected/readme-post-convert-filter.md
@@ -1,0 +1,127 @@
+# Plugin Name #
+**Contributors:** [stephenharris](https://profiles.wordpress.org/stephenharris)  
+**Donate link:** http://example.com/  
+**Tags:** comments, spam  
+**Requires at least:** 3.0.1  
+**Tested up to:** 3.4  
+**Stable tag:** 4.3  
+**License:** GPLv2 or later  
+**License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
+
+Here is a short description of the plugin.  This should be no more than 150 characters.  No markup here.
+
+## Description ##
+
+This is the long description.  No limit, and you can use Markdown (as well as in the following sections).
+
+For backwards compatibility, if this section is missing, the full length of the short description will be used, and
+Markdown parsed.
+
+A few notes about the sections above:
+
+*   "Contributors" is a comma separated list of wp.org/wp-plugins.org usernames
+*   "Tags" is a comma separated list of tags that apply to the plugin
+*   "Requires at least" is the lowest version that the plugin will work on
+*   "Tested up to" is the highest version that you've *successfully used to test the plugin*. Note that it might work on
+higher versions... this is just the highest one you've verified.
+*   Stable tag should indicate the Subversion "tag" of the latest stable version, or "trunk," if you use `/trunk/` for
+stable.
+
+    Note that the `readme.txt` of the stable tag is the one that is considered the defining one for the plugin, so
+if the `/trunk/readme.txt` file says that the stable tag is `4.3`, then it is `/tags/4.3/readme.txt` that'll be used
+for displaying information about the plugin.  In this situation, the only thing considered from the trunk `readme.txt`
+is the stable tag pointer.  Thus, if you develop in trunk, you can update the trunk `readme.txt` to reflect changes in
+your in-development version, without having that information incorrectly disclosed about the current stable version
+that lacks those changes -- as long as the trunk's `readme.txt` points to the correct stable tag.
+
+    If no stable tag is provided, it is assumed that trunk is stable, but you should specify "trunk" if that's where
+you put the stable version, in order to eliminate any doubt.
+
+## Installation ##
+
+This section describes how to install the plugin and get it working.
+
+e.g.
+
+1. Upload `plugin-name.php` to the `/wp-content/plugins/` directory
+1. Activate the plugin through the 'Plugins' menu in WordPress
+1. Place `<?php do_action('plugin_name_hook'); ?>` in your templates
+
+## Frequently Asked Questions ##
+
+### A question that someone might have ###
+
+An answer to that question.
+
+### What about foo bar? ###
+
+Answer to foo bar dilemma.
+
+## Screenshots ##
+
+### 1. This screen shot description corresponds to screenshot-1.(png|jpg|jpeg|gif). Note that the screenshot is taken from ###
+![This screen shot description corresponds to screenshot-1.(png|jpg|jpeg|gif). Note that the screenshot is taken from](http://ps.w.org/plugin-name/assets/screenshot-1.png)
+
+the /assets directory or the directory that contains the stable readme.txt (tags or trunk). Screenshots in the /assets 
+directory take precedence. For example, `/assets/screenshot-1.png` would win over `/tags/4.3/screenshot-1.png` 
+(or jpg, jpeg, gif).
+### 2. This is the second screen shot ###
+![This is the second screen shot](http://ps.w.org/plugin-name/assets/screenshot-2.png)
+
+
+## Changelog ##
+
+### 1.0 ###
+* A change since the previous version.
+* Another change.
+
+### 0.5 ###
+* List versions from most recent at top to oldest at bottom.
+
+## Upgrade Notice ##
+
+### 1.0 ###
+Upgrade notices describe the reason a user should upgrade.  No more than 300 characters.
+
+### 0.5 ###
+This version fixes a security related bug.  Upgrade immediately.
+
+* Item 1 changed
+* Changes: 1, 2, 3
+
+## Arbitrary section ##
+
+You may provide arbitrary sections, in the same format as the ones above.  This may be of use for extremely complicated
+plugins where more information needs to be conveyed that doesn't fit into the categories of "description" or
+"installation."  Arbitrary sections will be shown below the built-in sections outlined above.
+
+This is testing handling of semicolons: The first part SHOULD NOT be wrapped in asterisks. That should happen in the header section only.
+
+## A brief Markdown Example ##
+
+Ordered list:
+
+1. Some feature
+1. Another feature
+1. Something else about the plugin
+
+Unordered list:
+
+* something
+* something else
+* third thing
+
+Here's a link to [WordPress](http://wordpress.org/ "Your favorite software") and one to [Markdown's Syntax Documentation][markdown syntax].
+Titles are optional, naturally.
+
+[markdown syntax]: http://daringfireball.net/projects/markdown/syntax
+            "Markdown is what the parser uses to process much of the readme file"
+
+Markdown uses email style notation for blockquotes and I've been told:
+> Asterisks for *emphasis*. Double it up  for **strong**.
+
+`<?php code(); // goes in backticks ?>`
+
+== My Additional Header ==
+
+Header is not converted as it is added after conversion.

--- a/test/expected/readme-pre-convert-filter.md
+++ b/test/expected/readme-pre-convert-filter.md
@@ -1,0 +1,127 @@
+# Plugin Name #
+**Contributors:** [stephenharris](https://profiles.wordpress.org/stephenharris)  
+**Donate link:** http://example.com/  
+**Tags:** comments, spam  
+**Requires at least:** 3.0.1  
+**Tested up to:** 3.4  
+**Stable tag:** 4.3  
+**License:** GPLv2 or later  
+**License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
+
+Here is a short description of the plugin.  This should be no more than 150 characters.  No markup here.
+
+## Description ##
+
+This is the long description.  No limit, and you can use Markdown (as well as in the following sections).
+
+For backwards compatibility, if this section is missing, the full length of the short description will be used, and
+Markdown parsed.
+
+A few notes about the sections above:
+
+*   "Contributors" is a comma separated list of wp.org/wp-plugins.org usernames
+*   "Tags" is a comma separated list of tags that apply to the plugin
+*   "Requires at least" is the lowest version that the plugin will work on
+*   "Tested up to" is the highest version that you've *successfully used to test the plugin*. Note that it might work on
+higher versions... this is just the highest one you've verified.
+*   Stable tag should indicate the Subversion "tag" of the latest stable version, or "trunk," if you use `/trunk/` for
+stable.
+
+    Note that the `readme.txt` of the stable tag is the one that is considered the defining one for the plugin, so
+if the `/trunk/readme.txt` file says that the stable tag is `4.3`, then it is `/tags/4.3/readme.txt` that'll be used
+for displaying information about the plugin.  In this situation, the only thing considered from the trunk `readme.txt`
+is the stable tag pointer.  Thus, if you develop in trunk, you can update the trunk `readme.txt` to reflect changes in
+your in-development version, without having that information incorrectly disclosed about the current stable version
+that lacks those changes -- as long as the trunk's `readme.txt` points to the correct stable tag.
+
+    If no stable tag is provided, it is assumed that trunk is stable, but you should specify "trunk" if that's where
+you put the stable version, in order to eliminate any doubt.
+
+## Installation ##
+
+This section describes how to install the plugin and get it working.
+
+e.g.
+
+1. Upload `plugin-name.php` to the `/wp-content/plugins/` directory
+1. Activate the plugin through the 'Plugins' menu in WordPress
+1. Place `<?php do_action('plugin_name_hook'); ?>` in your templates
+
+## Frequently Asked Questions ##
+
+### A question that someone might have ###
+
+An answer to that question.
+
+### What about foo bar? ###
+
+Answer to foo bar dilemma.
+
+## Screenshots ##
+
+### 1. This screen shot description corresponds to screenshot-1.(png|jpg|jpeg|gif). Note that the screenshot is taken from ###
+![This screen shot description corresponds to screenshot-1.(png|jpg|jpeg|gif). Note that the screenshot is taken from](http://ps.w.org/plugin-name/assets/screenshot-1.png)
+
+the /assets directory or the directory that contains the stable readme.txt (tags or trunk). Screenshots in the /assets 
+directory take precedence. For example, `/assets/screenshot-1.png` would win over `/tags/4.3/screenshot-1.png` 
+(or jpg, jpeg, gif).
+### 2. This is the second screen shot ###
+![This is the second screen shot](http://ps.w.org/plugin-name/assets/screenshot-2.png)
+
+
+## Changelog ##
+
+### 1.0 ###
+* A change since the previous version.
+* Another change.
+
+### 0.5 ###
+* List versions from most recent at top to oldest at bottom.
+
+## Upgrade Notice ##
+
+### 1.0 ###
+Upgrade notices describe the reason a user should upgrade.  No more than 300 characters.
+
+### 0.5 ###
+This version fixes a security related bug.  Upgrade immediately.
+
+* Item 1 changed
+* Changes: 1, 2, 3
+
+## Arbitrary section ##
+
+You may provide arbitrary sections, in the same format as the ones above.  This may be of use for extremely complicated
+plugins where more information needs to be conveyed that doesn't fit into the categories of "description" or
+"installation."  Arbitrary sections will be shown below the built-in sections outlined above.
+
+This is testing handling of semicolons: The first part SHOULD NOT be wrapped in asterisks. That should happen in the header section only.
+
+## A brief Markdown Example ##
+
+Ordered list:
+
+1. Some feature
+1. Another feature
+1. Something else about the plugin
+
+Unordered list:
+
+* something
+* something else
+* third thing
+
+Here's a link to [WordPress](http://wordpress.org/ "Your favorite software") and one to [Markdown's Syntax Documentation][markdown syntax].
+Titles are optional, naturally.
+
+[markdown syntax]: http://daringfireball.net/projects/markdown/syntax
+            "Markdown is what the parser uses to process much of the readme file"
+
+Markdown uses email style notation for blockquotes and I've been told:
+> Asterisks for *emphasis*. Double it up  for **strong**.
+
+`<?php code(); // goes in backticks ?>`
+
+## My Additional Header ##
+
+ My additional text

--- a/test/expected/readme-screenshots-disabled.md
+++ b/test/expected/readme-screenshots-disabled.md
@@ -1,0 +1,111 @@
+# Plugin Name #
+**Contributors:** [stephenharris](https://profiles.wordpress.org/stephenharris)  
+**Donate link:** http://example.com/  
+**Tags:** comments, spam  
+**Requires at least:** 3.0.1  
+**Tested up to:** 3.4  
+**Stable tag:** 4.3  
+**License:** GPLv2 or later  
+**License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
+
+Here is a short description of the plugin.  This should be no more than 150 characters.  No markup here.
+
+## Description ##
+
+This is the long description.  No limit, and you can use Markdown (as well as in the following sections).
+
+For backwards compatibility, if this section is missing, the full length of the short description will be used, and
+Markdown parsed.
+
+A few notes about the sections above:
+
+*   "Contributors" is a comma separated list of wp.org/wp-plugins.org usernames
+*   "Tags" is a comma separated list of tags that apply to the plugin
+*   "Requires at least" is the lowest version that the plugin will work on
+*   "Tested up to" is the highest version that you've *successfully used to test the plugin*. Note that it might work on
+higher versions... this is just the highest one you've verified.
+*   Stable tag should indicate the Subversion "tag" of the latest stable version, or "trunk," if you use `/trunk/` for
+stable.
+
+    Note that the `readme.txt` of the stable tag is the one that is considered the defining one for the plugin, so
+if the `/trunk/readme.txt` file says that the stable tag is `4.3`, then it is `/tags/4.3/readme.txt` that'll be used
+for displaying information about the plugin.  In this situation, the only thing considered from the trunk `readme.txt`
+is the stable tag pointer.  Thus, if you develop in trunk, you can update the trunk `readme.txt` to reflect changes in
+your in-development version, without having that information incorrectly disclosed about the current stable version
+that lacks those changes -- as long as the trunk's `readme.txt` points to the correct stable tag.
+
+    If no stable tag is provided, it is assumed that trunk is stable, but you should specify "trunk" if that's where
+you put the stable version, in order to eliminate any doubt.
+
+## Installation ##
+
+This section describes how to install the plugin and get it working.
+
+e.g.
+
+1. Upload `plugin-name.php` to the `/wp-content/plugins/` directory
+1. Activate the plugin through the 'Plugins' menu in WordPress
+1. Place `<?php do_action('plugin_name_hook'); ?>` in your templates
+
+## Frequently Asked Questions ##
+
+### A question that someone might have ###
+
+An answer to that question.
+
+### What about foo bar? ###
+
+Answer to foo bar dilemma.
+
+## Changelog ##
+
+### 1.0 ###
+* A change since the previous version.
+* Another change.
+
+### 0.5 ###
+* List versions from most recent at top to oldest at bottom.
+
+## Upgrade Notice ##
+
+### 1.0 ###
+Upgrade notices describe the reason a user should upgrade.  No more than 300 characters.
+
+### 0.5 ###
+This version fixes a security related bug.  Upgrade immediately.
+
+* Item 1 changed
+* Changes: 1, 2, 3
+
+## Arbitrary section ##
+
+You may provide arbitrary sections, in the same format as the ones above.  This may be of use for extremely complicated
+plugins where more information needs to be conveyed that doesn't fit into the categories of "description" or
+"installation."  Arbitrary sections will be shown below the built-in sections outlined above.
+
+This is testing handling of semicolons: The first part SHOULD NOT be wrapped in asterisks. That should happen in the header section only.
+
+## A brief Markdown Example ##
+
+Ordered list:
+
+1. Some feature
+1. Another feature
+1. Something else about the plugin
+
+Unordered list:
+
+* something
+* something else
+* third thing
+
+Here's a link to [WordPress](http://wordpress.org/ "Your favorite software") and one to [Markdown's Syntax Documentation][markdown syntax].
+Titles are optional, naturally.
+
+[markdown syntax]: http://daringfireball.net/projects/markdown/syntax
+            "Markdown is what the parser uses to process much of the readme file"
+
+Markdown uses email style notation for blockquotes and I've been told:
+> Asterisks for *emphasis*. Double it up  for **strong**.
+
+`<?php code(); // goes in backticks ?>`

--- a/test/expected/readme-screenshots-disabled.md
+++ b/test/expected/readme-screenshots-disabled.md
@@ -57,6 +57,14 @@ An answer to that question.
 
 Answer to foo bar dilemma.
 
+## Screenshots ##
+
+1. This screen shot description corresponds to screenshot-1.(png|jpg|jpeg|gif). Note that the screenshot is taken from
+the /assets directory or the directory that contains the stable readme.txt (tags or trunk). Screenshots in the /assets 
+directory take precedence. For example, `/assets/screenshot-1.png` would win over `/tags/4.3/screenshot-1.png` 
+(or jpg, jpeg, gif).
+2. This is the second screen shot
+
 ## Changelog ##
 
 ### 1.0 ###

--- a/test/expected/readme-with-code-blocks.md
+++ b/test/expected/readme-with-code-blocks.md
@@ -1,5 +1,5 @@
 # Plugin Name #
-**Contributors:** (this should be a list of wordpress.org userid's)  
+**Contributors:** [stephenharris](https://profiles.wordpress.org/stephenharris)  
 **Donate link:** http://example.com/  
 **Tags:** comments, spam  
 **Requires at least:** 3.0.1  

--- a/test/expected/readme-with-spaces-after-headers.md
+++ b/test/expected/readme-with-spaces-after-headers.md
@@ -1,5 +1,5 @@
 # Plugin Name #
-**Contributors:** (this should be a list of wordpress.org userid's)       
+**Contributors:** [stephenharris](https://profiles.wordpress.org/stephenharris)  
 **Donate link:** http://example.com/       
 **Tags:** comments, spam        
 **Requires at least:** 3.0.1       

--- a/test/expected/readme-with-spaces-between-plugin-details.md
+++ b/test/expected/readme-with-spaces-between-plugin-details.md
@@ -1,5 +1,5 @@
 # Plugin Name #
-**Contributors:** (this should be a list of wordpress.org userid's)  
+**Contributors:** [stephenharris](https://profiles.wordpress.org/stephenharris)  
 
 **Donate link:** http://example.com/  
 

--- a/test/expected/readme-without-screenshots.md
+++ b/test/expected/readme-without-screenshots.md
@@ -1,5 +1,5 @@
 # Plugin Name #
-**Contributors:** (this should be a list of wordpress.org userid's)  
+**Contributors:** [stephenharris](https://profiles.wordpress.org/stephenharris)  
 **Donate link:** http://example.com/  
 **Tags:** comments, spam  
 **Requires at least:** 3.0.1  

--- a/test/expected/readme.md
+++ b/test/expected/readme.md
@@ -1,5 +1,5 @@
 # Plugin Name #
-**Contributors:** (this should be a list of wordpress.org userid's)  
+**Contributors:** [stephenharris](https://profiles.wordpress.org/stephenharris)  
 **Donate link:** http://example.com/  
 **Tags:** comments, spam  
 **Requires at least:** 3.0.1  

--- a/test/fixtures/readme-with-code-blocks.txt
+++ b/test/fixtures/readme-with-code-blocks.txt
@@ -1,5 +1,5 @@
 === Plugin Name ===
-Contributors: (this should be a list of wordpress.org userid's)
+Contributors: stephenharris
 Donate link: http://example.com/
 Tags: comments, spam
 Requires at least: 3.0.1

--- a/test/fixtures/readme-with-spaces-after-headers.txt
+++ b/test/fixtures/readme-with-spaces-after-headers.txt
@@ -1,5 +1,5 @@
 === Plugin Name ===     
-Contributors: (this should be a list of wordpress.org userid's)     
+Contributors: stephenharris     
 Donate link: http://example.com/     
 Tags: comments, spam      
 Requires at least: 3.0.1     

--- a/test/fixtures/readme-with-spaces-between-plugin-details.txt
+++ b/test/fixtures/readme-with-spaces-between-plugin-details.txt
@@ -1,5 +1,5 @@
 === Plugin Name ===
-Contributors: (this should be a list of wordpress.org userid's)
+Contributors: stephenharris
 
 Donate link: http://example.com/
 

--- a/test/fixtures/readme-without-screenshots.txt
+++ b/test/fixtures/readme-without-screenshots.txt
@@ -1,5 +1,5 @@
 === Plugin Name ===
-Contributors: (this should be a list of wordpress.org userid's)
+Contributors: stephenharris
 Donate link: http://example.com/
 Tags: comments, spam
 Requires at least: 3.0.1

--- a/test/fixtures/readme.txt
+++ b/test/fixtures/readme.txt
@@ -1,5 +1,5 @@
 === Plugin Name ===
-Contributors: (this should be a list of wordpress.org userid's)
+Contributors: stephenharris
 Donate link: http://example.com/
 Tags: comments, spam
 Requires at least: 3.0.1

--- a/test/wp_readme_to_markdown_test.js
+++ b/test/wp_readme_to_markdown_test.js
@@ -76,5 +76,14 @@ exports.wp_readme_to_markdown = {
 
     test.done();
   },
+  
+  with_screenshots_disabled: function( test ){
+    test.expect(1);
 
+    var actual = grunt.file.read('tmp/readme-screenshots-disabled.md');
+    var expected = grunt.file.read('test/expected/readme-screenshots-disabled.md');
+    test.equal(actual, expected );
+
+    test.done();
+  },
 };

--- a/test/wp_readme_to_markdown_test.js
+++ b/test/wp_readme_to_markdown_test.js
@@ -86,4 +86,24 @@ exports.wp_readme_to_markdown = {
 
     test.done();
   },
+
+  with_appended_header_pre_convert: function( test ){
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/readme-pre-convert-filter.md');
+    var expected = grunt.file.read('test/expected/readme-pre-convert-filter.md');
+    test.equal(actual, expected );
+
+    test.done();
+  },
+  
+  with_appended_header_post_convert: function( test ){
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/readme-post-convert-filter.md');
+    var expected = grunt.file.read('test/expected/readme-post-convert-filter.md');
+    test.equal(actual, expected );
+
+    test.done();
+  },
 };

--- a/test/wp_readme_to_markdown_test.js
+++ b/test/wp_readme_to_markdown_test.js
@@ -68,13 +68,13 @@ exports.wp_readme_to_markdown = {
   },
   
   with_code_blocks: function( test ){
-	    test.expect(1);
+    test.expect(1);
 
-	    var actual = grunt.file.read('tmp/readme-with-code-blocks.md');
-	    var expected = grunt.file.read('test/expected/readme-with-code-blocks.md');
-	    test.equal(actual, expected );
+    var actual = grunt.file.read('tmp/readme-with-code-blocks.md');
+    var expected = grunt.file.read('test/expected/readme-with-code-blocks.md');
+    test.equal(actual, expected );
 
-	    test.done();
+    test.done();
   },
 
 };


### PR DESCRIPTION
- **Breaking change:** The default value of `screenshot_url` has been changed from `http://ps.w.org/{plugin}/assets/{screenshot}.png` to `false`. By default no screenshot images are included in the generated `readme.md`. Please see [#14](https://github.com/stephenharris/wp-readme-to-markdown/issues/14) for details.
- Contributors have their links to their wordpress.org profile automatically inserted. [#12](https://github.com/stephenharris/wp-readme-to-markdown/issues/12)
- Added `pre_convert` and `post_convert` options