### PR TITLE
Update peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "grunt": "~0.4.1"
   },
   "peerDependencies": {
-    "grunt": "~0.4.1"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin"


### PR DESCRIPTION
See http://gruntjs.com/blog/2016-04-04-grunt-1.0.0-released#peer-dependencies

`npm ERR! peerinvalid Peer grunt-wp-readme-to-markdown@2.0.0 wants grunt@~0.4.1`
