### PR TITLE
Fixed a bug with contributors

### DIFF
--- a/tasks/wp_readme_to_markdown.js
+++ b/tasks/wp_readme_to_markdown.js
@@ -60,7 +60,7 @@ module.exports = function(grunt) {
 		// Include w.org profiles for contributors.
 		grunt.log.debug("Including contributors profiles");
 		var contributors_match = readme.match( new RegExp("(\\*\\*Contributors:\\*\\* )(.+)", "m") );
-		if ( header_match && header_match.length >= 1 ) {
+		if ( contributors_match && contributors_match.length >= 1 ) {
 			var contributors_search = contributors_match[0];
 			var contributors_replace = contributors_match[1];
 			var profiles = [];


### PR DESCRIPTION
The check around contributors looks for a value in `header_match` instead of `contributors_match`.